### PR TITLE
Use updated lib pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     keywords='myjdapi jdownloader my.jdownloader api development',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     # py_modules=["libgenapi"],
-    install_requires=['requests','pycrypto'],
+    install_requires=['requests','pycryptodome'],
 )


### PR DESCRIPTION
Had some errors when installing pycrypto on python3 needing vc+ etc,

I saw it's pretty ancient, pycryptodome is the updated version. no other code needs changing it uses the same:
from Crypto.Cipher import AES