### PR TITLE
feat() Improvements on `query_links` and `query_packages`

### DIFF
--- a/myjdapi/myjdapi.py
+++ b/myjdapi/myjdapi.py
@@ -639,23 +639,27 @@ class Downloads:
 
     def query_links(self,
                     params=[{
+                        "addedDate": True,
+                        "bytesLoaded": True,
                         "bytesTotal": True,
                         "comment": True,
-                        "status": True,
                         "enabled": True,
-                        "maxResults": -1,
-                        "startAt": 0,
-                        "packageUUIDs": [],
-                        "host": True,
-                        "url": True,
-                        "bytesloaded": True,
-                        "speed": True,
                         "eta": True,
+                        "extractionStatus": True,
                         "finished": True,
+                        "finishedDate": True,
+                        "host": True,
+                        "jobUUIDs": [],
+                        "maxResults": -1,
+                        "packageUUIDs": [],
+                        "password": True,
                         "priority": True,
                         "running": True,
                         "skipped": True,
-                        "extractionStatus": True
+                        "speed": True,
+                        "startAt": 0,
+                        "status": True,
+                        "url": True
                     }]):
         """
         Get the links in the download list
@@ -667,19 +671,20 @@ class Downloads:
                        params=[{
                            "bytesLoaded": True,
                            "bytesTotal": True,
+                           "childCount": True,
                            "comment": True,
                            "enabled": True,
                            "eta": True,
-                           "priority": True,
                            "finished": True,
-                           "running": True,
-                           "speed": True,
-                           "status": True,
-                           "childCount": True,
                            "hosts": True,
-                           "saveTo": True,
                            "maxResults": -1,
+                           "packageUUIDs": [],
+                           "priority": True,
+                           "running": True,
+                           "saveTo": True,
+                           "speed": True,
                            "startAt": 0,
+                           "status": True
                        }]):
         """
         Get the packages in the download list


### PR DESCRIPTION
feat() Improvements on `query_links` and `query_packages`
 - `query_links`: Fixed wrong case on `bytesLoaded` and added missing parameters `addedDate`, `finishedDate`, `jobUUIDs`, `password`.
 - `query_packages`: Added missing parameter `packageUUIDs`.

I also changed the order of parameters to match the order on documentation site, for easier comparision: [PackageQuery](https://my.jdownloader.org/developers/#tag_98), [LinkQuery](https://my.jdownloader.org/developers/#tag_98)