### PR TITLE
Inherit Exception instead of BaseException

### DIFF
--- a/myjdapi/exception.py
+++ b/myjdapi/exception.py
@@ -31,7 +31,7 @@ from .const import (
 )
 
 
-class MYJDException(BaseException):
+class MYJDException(Exception):
     """Base MyJDownloader Exception."""
 
     pass


### PR DESCRIPTION
This pull request is to fix "TypeError: cannot unpack non-iterable ExceptionInfo object"

I got error below for my gevent + this lib setup.

```
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 900, in gevent._gevent_cgreenlet.Greenlet.run
  File "/usr/local/lib/python3.11/site-packages/celery/concurrency/base.py", line 42, in apply_target
    callback(ExceptionInfo())
  File "/usr/local/lib/python3.11/site-packages/celery/worker/request.py", line 772, in on_success
    failed, retval, runtime = failed__retval__runtime
    ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable ExceptionInfo object
2025-01-16T18:50:30Z <Greenlet at 0x73e7c71d19e0: apply_target(<function fast_trace_task at 0x73e7cd04c900>, ('downloadLink', 'ede90eb5-9553-4bbe-9201-7e2afed4, {}, <bound method create_request_cls.<locals>.Request., <bound method Request.on_accepted of <Request: dow, timeout=None, timeout_callback=<bound method Request.on_timeout of <Request: down)> failed with TypeError
```
The error is because MYJDException is inherited from BaseException instead of Exception.

```
Derive exceptions from Exception rather than BaseException. Direct inheritance from BaseException is reserved for exceptions where catching them is almost always the wrong thing to do.
Design exception hierarchies based on the distinctions that code catching the exceptions is likely to need, rather than the locations where the exceptions are raised. Aim to answer the question “What went wrong?” programmatically, rather than only stating that “A problem occurred” (see [PEP 3151](https://peps.python.org/pep-3151/) for an example of this lesson being learned for the builtin exception hierarchy)
```
from https://peps.python.org/pep-0008/#programming-recommendations

Also, from https://docs.python.org/3/library/exceptions.html#Exception
